### PR TITLE
Add R-CMD-check GitHub Actions workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,50 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![DOI](https://zenodo.org/badge/192684959.svg)](https://zenodo.org/badge/latestdoi/192684959)
+[![R-CMD-check](https://github.com/joelnitta/taxastand/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/joelnitta/taxastand/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/joelnitta/taxastand/graph/badge.svg)](https://app.codecov.io/gh/joelnitta/taxastand)
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 has not yet been a stable, usable release suitable for the
 public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![DOI](https://zenodo.org/badge/192684959.svg)](https://zenodo.org/badge/latestdoi/192684959)
+[![R-CMD-check](https://github.com/joelnitta/taxastand/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/joelnitta/taxastand/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
 coverage](https://codecov.io/gh/joelnitta/taxastand/graph/badge.svg)](https://app.codecov.io/gh/joelnitta/taxastand)
 <!-- badges: end -->

--- a/tests/testthat/test-engine-vs-docker.R
+++ b/tests/testthat/test-engine-vs-docker.R
@@ -17,10 +17,10 @@ docker_tt <- function(dir, args) {
 skip_if_no_image <- function() {
   skip_if_no_docker()
   ok <- tryCatch(
-    length(suppressWarnings(system2(
+    system2(
       "docker", c("image", "inspect", tt_image),
-      stdout = TRUE, stderr = FALSE
-    ))) > 0,
+      stdout = FALSE, stderr = FALSE
+    ) == 0,
     error = function(e) FALSE
   )
   if (!isTRUE(ok)) testthat::skip(paste("docker image", tt_image, "not present"))


### PR DESCRIPTION
## Summary
- Adds the standard `r-lib/actions` R-CMD-check workflow covering macOS/Windows/Ubuntu across release, devel, and oldrel R versions.
- Adds the resulting R-CMD-check badge to README.

## Test plan
- [x] `devtools::test()` passes locally (39 passed, 0 failed; the Docker-comparison test ran locally since Docker is available here, and will self-skip in CI via its existing `skip_if_no_docker()`/`skip_if_no_image()` guards since the `camwebb/taxon-tools:v1.3.0` image won't be pre-pulled on GitHub runners).
- [x] Confirm the new workflow passes on GitHub Actions once opened (CI will run automatically on this PR).

Closes #15