### PR TITLE
Add test coverage workflow and Codecov integration

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^Meta$
 ^\.claude$
 ^\.plans$
+^codecov\.yml$

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,60 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: test-coverage.yaml
+
+permissions: read-all
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
+
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          print(cov)
+          covr::to_cobertura(cov)
+        shell: Rscript {0}
+
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Roxygen: list(
     roclets = c("collate", "namespace", "rd", "roxyglobals::global_roclet"))
 Depends: R (>= 4.1.0)
 Suggests:
+    covr,
     rmarkdown,
     knitr,
     roxyglobals (>= 0.2.1),

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![DOI](https://zenodo.org/badge/192684959.svg)](https://zenodo.org/badge/latestdoi/192684959)
+[![Codecov test coverage](https://codecov.io/gh/joelnitta/taxastand/graph/badge.svg)](https://app.codecov.io/gh/joelnitta/taxastand)
 <!-- badges: end -->
 
 The goal of `taxastand` is to standardize species names from different sources, a common task in biology. 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 has not yet been a stable, usable release suitable for the
 public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![DOI](https://zenodo.org/badge/192684959.svg)](https://zenodo.org/badge/latestdoi/192684959)
+[![Codecov test
+coverage](https://codecov.io/gh/joelnitta/taxastand/graph/badge.svg)](https://app.codecov.io/gh/joelnitta/taxastand)
 <!-- badges: end -->
 
 The goal of `taxastand` is to standardize species names from different

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
## Summary
- Adds `covr` to `Suggests`.
- Adds `codecov.yml` and the `test-coverage` GitHub Actions workflow (via `usethis::use_coverage()` + `usethis::use_github_action("test-coverage")`).
- Adds the Codecov badge to README.

## Note
This repo isn't yet connected to Codecov. For uploads to succeed (and to avoid CI failing on push, per `fail_ci_if_error` in the workflow), enable the repo at https://app.codecov.io and, if needed, add a `CODECOV_TOKEN` repository secret per https://docs.codecov.com/docs/adding-the-codecov-token. I can't do this step myself since it requires the GitHub/Codecov web UI — flagging so you can complete it after merge.

## Test plan
- [x] `devtools::build_readme()` re-knit cleanly.
- [ ] Confirm the workflow runs successfully on GitHub Actions (will run automatically on this PR, though the Codecov upload step may need the token set up per the note above).

Closes #16