### PR TITLE
Review runtime dependency footprint (assertr vs assertthat)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,6 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports:
-    assertr,
     assertthat,
     digest,
     dplyr,

--- a/R/globals.R
+++ b/R/globals.R
@@ -25,7 +25,6 @@ utils::globalVariables(c(
   "matched_name", # <ts_resolve_names>
   "matched_status", # <ts_resolve_names>
   "query", # <ts_classify_result>
-  "result_type", # <ts_classify_result>
   "n", # <ts_classify_result>
   NULL
 ))

--- a/R/ts_parse_names.R
+++ b/R/ts_parse_names.R
@@ -47,7 +47,7 @@ ts_parse_names <- function(
     msg = "Input taxa may not contain NAs"
   )
   assertthat::assert_that(
-    all(assertr::is_uniq(taxa)),
+    !anyDuplicated(taxa),
     msg = "Input taxa must be unique"
   )
   assertthat::assert_that(assertthat::is.flag(tbl_out))

--- a/R/ts_resolve_names.R
+++ b/R/ts_resolve_names.R
@@ -185,9 +185,16 @@ ts_resolve_names <- function(
     dplyr::anti_join(success, by = "query")
 
   # Combine into final results
-  results <- dplyr::bind_rows(success, failure) %>%
-    assertr::verify(all(query %in% match_results$query)) %>%
-    assertr::verify(all(match_results$query %in% query)) %>%
+  results_raw <- dplyr::bind_rows(success, failure)
+  assertthat::assert_that(
+    all(results_raw$query %in% match_results$query),
+    msg = "query values in results must all be present in match_results"
+  )
+  assertthat::assert_that(
+    all(match_results$query %in% results_raw$query),
+    msg = "query values in match_results must all be present in results"
+  )
+  results <- results_raw %>%
     dplyr::select(
       query,
       resolved_name,

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,7 +16,7 @@ ts_make_name_df <- function(taxa) {
     msg = "Input taxa may not contain NAs"
   )
   assertthat::assert_that(
-    all(assertr::is_uniq(taxa)),
+    !anyDuplicated(taxa),
     msg = "Input taxa must be unique"
   )
 
@@ -42,7 +42,7 @@ ts_classify_result <- function(match_results) {
     inherits(match_results, "data.frame"),
     msg = "match_results must be of class 'data.frame'"
   )
-  match_results %>%
+  result <- match_results %>%
     dplyr::add_count(query) %>%
     dplyr::mutate(
       result_type = dplyr::case_when(
@@ -51,8 +51,12 @@ ts_classify_result <- function(match_results) {
         match_type == "no_match" ~ "no_match",
         TRUE ~ NA_character_
       )
-    ) %>%
-    assertr::assert(assertr::not_na, result_type) %>%
+    )
+  assertthat::assert_that(
+    !anyNA(result$result_type),
+    msg = "result_type must not be NA"
+  )
+  result %>%
     dplyr::select(-n)
 }
 


### PR DESCRIPTION
## Summary
- Removed `assertr` from `Imports`, consolidating all validation logic on `assertthat` (which was already used 38x elsewhere in the package, vs. `assertr`'s 5 uses across 3 files).
- Replaced `assertr::is_uniq()` uniqueness checks with base R `!anyDuplicated()`.
- Replaced two mid-pipe `assertr::assert()`/`assertr::verify()` calls (which check a condition on a piped dataframe and pass it through) with an explicit assign -> `assertthat::assert_that()` -> continue pattern, since `assertthat` doesn't have a pipe-passthrough verifier.
- Regenerated `R/globals.R` via `roxyglobals`: `result_type` is no longer flagged as a bare NSE global now that it's accessed via `result$result_type` instead of inside an NSE-evaluated `assertr::assert()` call.
- Confirmed all remaining `Imports` (`assertthat`, `digest`, `dplyr`, `fs`, `glue`, `magrittr`, `tibble`, `tidyr`) are actively used via `grep -rn "<pkg>::" R/`.

## Test plan
- [x] `devtools::test()` passes locally (39 passed, 0 failed) — same result as before the change.
- [x] `devtools::document()` regenerates docs cleanly with no unexpected diffs beyond the expected `R/globals.R` change.
- [x] CI (R-CMD-check + coverage) will validate on this PR.

Closes #23