### PR TITLE
Drop non-CRAN Remotes: field for roxyglobals (now on CRAN)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,10 +27,8 @@ Suggests:
     covr,
     rmarkdown,
     knitr,
-    roxyglobals (>= 0.2.1),
+    roxyglobals (>= 1.0.0),
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-Remotes: 
-    anthonynorth/roxyglobals
 VignetteBuilder: knitr
 Config/roxygen2/version: 8.0.0


### PR DESCRIPTION
## Summary
Original approach (first commit) removed `roxyglobals` entirely and hand-maintained `R/globals.R`. Revised after noticing `roxyglobals` is now published on CRAN (1.0.0, since 2023-08-21) — so the real fix is much smaller: just drop the non-CRAN `Remotes:` field and depend on the CRAN release instead. This preserves the auto-generated `R/globals.R` workflow rather than switching to hand-maintenance.

- Removed `Remotes: anthonynorth/roxyglobals` from DESCRIPTION.
- Bumped the `Suggests` version constraint to `roxyglobals (>= 1.0.0)` to reflect the CRAN release.
- Kept the `roxyglobals::global_roclet` in the `Roxygen` roclets list and all `@autoglobal` tags — no change to the documented workflow.
- Confirmed: installed `roxyglobals` 1.0.0 from CRAN locally, ran `devtools::document()`, and `R/globals.R` regenerated byte-for-byte identical to before.

All dependencies are now installable from CRAN — confirmed via `desc::desc_get_deps()`.

## Test plan
- [x] `devtools::document()` with CRAN roxyglobals 1.0.0 regenerates `R/globals.R` identically (no diff).
- [x] `devtools::test()` passes locally (39 passed, 0 failed).
- [x] CI will validate on this PR.

Closes #13