### PR TITLE
Polish DESCRIPTION metadata for rOpenSci/CRAN conventions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,11 +5,21 @@ Authors@R:
     person(given = "Joel",
            family = "Nitta",
            role = c("aut", "cre"),
-           email = "joelnitta@gmail.com")
-Description: Matches species names to a taxonomic standard. Resolves synonyms consistently and reproducibly.
+           email = "joelnitta@gmail.com",
+           comment = c(ORCID = "0000-0003-4719-7472"))
+Description: Standardizes taxonomic names by matching species names to
+    entries in a user-supplied reference taxonomy, then resolving synonyms
+    to their accepted names. Fuzzy matching on parsed name components
+    (genus, epithet, author, infraspecific rank, etc.) allows for
+    orthographic differences between the query and reference names.
+    This facilitates reproducible joining of datasets that use different
+    taxonomic synonyms for the same species.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
+URL: https://joelnitta.github.io/taxastand/,
+    https://github.com/joelnitta/taxastand
+BugReports: https://github.com/joelnitta/taxastand/issues
 Imports:
     assertthat,
     digest,


### PR DESCRIPTION
## Summary
- Expanded `Description:` from one terse sentence to a full paragraph explaining what the package does (matching + fuzzy matching + synonym resolution against a user-supplied reference).
- Added `URL:` (pkgdown site + GitHub repo) and `BugReports:` fields.
- Added Joel's ORCID to `Authors@R`.
- `Title:` was already Title Case with no trailing period, so left unchanged.

## Test plan
- [x] `devtools::test()` passes locally (39 passed, 0 failed).
- [x] `desc::desc()` parses all new/changed fields correctly, including a valid ORCID.
- [x] CI will validate on this PR.

Closes #12