### PR TITLE
Fix documentation left over from the pre-2.0 taxon-tools architecture

### DIFF
--- a/R/ts_match_names.R
+++ b/R/ts_match_names.R
@@ -37,8 +37,8 @@
 #' must be unique. If a dataframe, should be taxonomic names parsed with
 #' \code{\link{ts_parse_names}()}.
 #' @param manual_match Optional. Dataframe of manually matched names that will
-#' override any results from `taxon-tools`. Must include columns, `query`
-#' and `match`. Can only be used if `query` is a character vector.
+#' override any results from the name-matching engine. Must include columns,
+#' `query` and `match`. Can only be used if `query` is a character vector.
 #' @param max_dist Max Levenshtein distance to allow during fuzzy matching
 #' (total insertions, deletions and substitutions). Default: 10.
 #' @param match_no_auth Logical; If no author is given in the query and the name

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,8 @@
 #' Make a dataframe with taxonomic names
 #'
-#' @param taxa Character vector; taxon names to be parsed by taxon-tools `parsenames`.
-#' Missing values not allowed. Must all be unique.
+#' @param taxa Character vector; taxon names to be parsed by
+#' \code{\link{ts_parse_names}()} (via the internal pure-R parsing engine,
+#' `tt_parsenames()`). Missing values not allowed. Must all be unique.
 #'
 #' @return Dataframe with two columns: `id` and `name`
 #' @keywords internal
@@ -30,9 +31,9 @@ ts_make_name_df <- function(taxa) {
   taxa_df[, c("id", "name")]
 }
 
-#' Classify results of taxon-tools matching
+#' Classify results of name matching
 #'
-#' @param match_results Dataframe; output of tt_match_names()
+#' @param match_results Dataframe; output of \code{\link{ts_match_names}()}
 #'
 #' @return Dataframe with column `result_type` added
 #' @keywords internal

--- a/man/ts_classify_result.Rd
+++ b/man/ts_classify_result.Rd
@@ -2,17 +2,17 @@
 % Please edit documentation in R/utils.R
 \name{ts_classify_result}
 \alias{ts_classify_result}
-\title{Classify results of taxon-tools matching}
+\title{Classify results of name matching}
 \usage{
 ts_classify_result(match_results)
 }
 \arguments{
-\item{match_results}{Dataframe; output of tt_match_names()}
+\item{match_results}{Dataframe; output of \code{\link{ts_match_names}()}}
 }
 \value{
 Dataframe with column \code{result_type} added
 }
 \description{
-Classify results of taxon-tools matching
+Classify results of name matching
 }
 \keyword{internal}

--- a/man/ts_make_name_df.Rd
+++ b/man/ts_make_name_df.Rd
@@ -7,8 +7,9 @@
 ts_make_name_df(taxa)
 }
 \arguments{
-\item{taxa}{Character vector; taxon names to be parsed by taxon-tools \code{parsenames}.
-Missing values not allowed. Must all be unique.}
+\item{taxa}{Character vector; taxon names to be parsed by
+\code{\link{ts_parse_names}()} (via the internal pure-R parsing engine,
+\code{tt_parsenames()}). Missing values not allowed. Must all be unique.}
 }
 \value{
 Dataframe with two columns: \code{id} and \code{name}

--- a/man/ts_match_names.Rd
+++ b/man/ts_match_names.Rd
@@ -30,8 +30,8 @@ must be unique. If a dataframe, should be taxonomic names parsed with
 \code{\link{ts_parse_names}()}.}
 
 \item{manual_match}{Optional. Dataframe of manually matched names that will
-override any results from \code{taxon-tools}. Must include columns, \code{query}
-and \code{match}. Can only be used if \code{query} is a character vector.}
+override any results from the name-matching engine. Must include columns,
+\code{query} and \code{match}. Can only be used if \code{query} is a character vector.}
 
 \item{max_dist}{Max Levenshtein distance to allow during fuzzy matching
 (total insertions, deletions and substitutions). Default: 10.}


### PR DESCRIPTION
## Summary
Fixed roxygen docs that still implied the external `taxon-tools` CLI is invoked at runtime, which stopped being true when v2.0 replaced it with a pure-R engine:

- `ts_make_name_df()`'s `taxa` param doc said names are "parsed by taxon-tools \`parsenames\`" -> now points to `ts_parse_names()` / the internal `tt_parsenames()` engine.
- `ts_classify_result()`'s title/param doc said "Classify results of taxon-tools matching" / "output of tt_match_names()" (also just a wrong function name — the real internal one is `tt_matchnames()`) -> now correctly documents it as taking the output of the exported `ts_match_names()`.
- `ts_match_names()`'s `manual_match` param doc said it overrides "results from \`taxon-tools\`" -> now "the name-matching engine".

Left untouched the comments/docs that accurately describe this as a pure-R reimplementation/port of taxon-tools (`matchnames_engine.R`, `parsenames_engine.R`, the "see taxon-tools manual" links explaining `match_type` codes, and the taxon-tools-compatible file format used internally by `ts_write_names()`) — those are correct as written and not in scope.

## Test plan
- [x] `devtools::document()` regenerates the 3 affected `.Rd` files correctly.
- [x] `devtools::test()` passes locally (39 passed, 0 failed).
- [x] CI will validate on this PR.

Closes #19