### PR TITLE
Add lintr config, run styler, fix lint findings, add lint CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,31 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: lint.yaml
+
+permissions: read-all
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::lintr, local::.
+          needs: lint
+
+      - name: Lint
+        run: lintr::lint_package()
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,13 @@
+linters: lintr::linters_with_defaults(
+    # indentation_linter disagrees with styler on continuation indents for
+    # multi-line operator chains; styler is the formatting authority here.
+    indentation_linter = NULL,
+    # The package deliberately uses magrittr's %>% throughout (and
+    # re-exports it for users in R/utils-pipe.R); not switching to |>.
+    pipe_consistency_linter = NULL,
+    # Many roxygen doc lines contain long, unbreakable markdown links
+    # (e.g. Darwin Core term URLs); wrapping them would be worse than
+    # leaving them long.
+    line_length_linter = NULL
+  )
+encoding: "UTF-8"

--- a/R/matchnames_engine.R
+++ b/R/matchnames_engine.R
@@ -4,15 +4,18 @@
 # Faithful port of the gawk script `matchnames` from taxon-tools v1.3.0
 # (camwebb/taxon-tools, upstream commit 8f8b5e2). The interactive `-f`
 # matching, the `-m` manual-choices file, and stdin prompting are intentionally
-# omitted (out of scope; never invoked by taxastand).
+# omitted (out of scope; never invoked by taxastand). Variable names below
+# (A, B, Bmap, etc.) intentionally mirror the gawk source's array names for
+# traceability against the upstream script.
+# nolint start: object_name_linter.
 #
 # Input is the parsed pipe-delimited format produced by tt_parsenames /
-# ts_write_names: id|g_hybrid|genus|s_hybrid|species|rank|infrasp|author
+# ts_write_names: id|g_hybrid|genus|s_hybrid|species|rank|infrasp|author # nolint: commented_code_linter.
 # Output is the 17-field result format documented in ts_match_names().
 #
 # Fuzzy matching uses base adist() (Levenshtein); the original uses gawk's
 # anchored amatch(), documented in-source as equivalent to
-# levenshtein(...) <= FUZZERR.
+# levenshtein(...) <= FUZZERR. # nolint: commented_code_linter.
 
 # Collapse internal/leading/trailing spaces (matchnames `cleanspaces`)
 .tt_cleanspaces <- function(x) {
@@ -60,7 +63,7 @@
   data <- paste(xg, g, xs, s, st, ssp, a, sep = "|")
   exact <- .tt_cleanspaces(paste(xg, g, xs, s, st, ssp, a))
 
-  namex <- paste0(xg, g, xs, s, st, ssp)         # all parts, no author
+  namex <- paste0(xg, g, xs, s, st, ssp) # all parts, no author
   punct <- tt_depunct(paste0(namex, a))
   noauth <- tt_depunct(namex)
   cfonly <- tt_depunct(paste0(g, s, ssp))
@@ -149,8 +152,10 @@ tt_matchnames <- function(query_lines, ref_lines, max_dist = 10,
   B <- .tt_record_keys(ref_lines)
   A <- .tt_record_keys(query_lines)
 
-  methods <- c("exact", "punct", "noauth", "cfonly", "irank",
-               "basio", "in", "exin", "basexin")
+  methods <- c(
+    "exact", "punct", "noauth", "cfonly", "irank",
+    "basio", "in", "exin", "basexin"
+  )
   Bmap <- lapply(methods, function(m) .tt_build_map(B[[m]], B$code))
   names(Bmap) <- methods
 
@@ -168,8 +173,10 @@ tt_matchnames <- function(query_lines, ref_lines, max_dist = 10,
 
   # emit a standard 17-field line: qcode|rcode|type|<qdata>|<rdata>
   line_match <- function(qi, rcode, type) {
-    paste0(A$code[qi], "|", rcode, "|", type, "|",
-           A$data[qi], "|", .tt_get(Bdata, rcode))
+    paste0(
+      A$code[qi], "|", rcode, "|", type, "|",
+      A$data[qi], "|", .tt_get(Bdata, rcode)
+    )
   }
   line_nomatch <- function(qi) {
     paste0(A$code[qi], "||no_match|", A$data[qi], "|||||||")
@@ -207,7 +214,9 @@ tt_matchnames <- function(query_lines, ref_lines, max_dist = 10,
   test_allfuzzy <- function(qi) {
     cand <- Bgenus_codes[[A$genus[qi]]]
     cand <- cand[cand != A$code[qi]]
-    if (!length(cand)) return(NULL)
+    if (!length(cand)) {
+      return(NULL)
+    }
     qp <- A$punct[qi]
     rp <- Bpunct_by_code[cand]
     # gawk's amatch(text = ref, "^query$", FUZZERR) accepts a pair when its
@@ -224,7 +233,9 @@ tt_matchnames <- function(query_lines, ref_lines, max_dist = 10,
       keep[bnd] <- .tt_amatch_trailing(qp, rp[bnd], d[bnd]) == 0L
     }
     hit <- cand[keep]
-    if (!length(hit)) return(NULL)
+    if (!length(hit)) {
+      return(NULL)
+    }
     vapply(hit, function(rc) line_match(qi, rc, "auto_fuzzy"), character(1))
   }
 
@@ -258,3 +269,4 @@ tt_matchnames <- function(query_lines, ref_lines, max_dist = 10,
 
   unlist(out, use.names = FALSE)
 }
+# nolint end

--- a/R/parsenames_engine.R
+++ b/R/parsenames_engine.R
@@ -22,13 +22,13 @@
 #   1 genus hybrid | 2 genus | 3 species hybrid | 4 species |
 #   5 infraspecific rank | 6 infraspecific epithet | 7 author string
 .tt_parse_re <- paste0(
-  "(*UCP)",                                       # Unicode-aware POSIX classes
-  "^([\u00d7xX]?) ?",                                  # 1 genus hybrid sign
-  "([A-Z][a-z\u00eb-]+) ?",                            # 2 genus name
-  "([\u00d7xX]? |[\u00d7X]?) ?",                       # 3 species hybrid sign
-  "([a-z\ufb02-][a-z\ufb02-]+)? ?",                    # 4 specific epithet
+  "(*UCP)", # Unicode-aware POSIX classes
+  "^([\u00d7xX]?) ?", # 1 genus hybrid sign
+  "([A-Z][a-z\u00eb-]+) ?", # 2 genus name
+  "([\u00d7xX]? |[\u00d7X]?) ?", # 3 species hybrid sign
+  "([a-z\ufb02-][a-z\ufb02-]+)? ?", # 4 specific epithet
   "(var\\.|f\\.|forma|subf\\.|taxon|fo\\.|subsp\\.|prol\\.|nothovar\\.|lus\\.|\\[infrasp\\.unranked\\])? ?", # 5 rank
-  "([a-z\ufb02_-]+)? ?",                               # 6 infraspecific epithet
+  "([a-z\ufb02_-]+)? ?", # 6 infraspecific epithet
   # 7 author: ']' placed first (literal), '-' last (literal); includes
   # [:alnum:] plus the combining diacritics used in author names
   "([] [().&;,\u2019'[:alnum:]\u0301 \u0300 \u0308 \u0306 \u030c \u0327 \u0326 \u0303 \u030a \u0302 -]+)?$"
@@ -53,28 +53,28 @@
 #' @noRd
 tt_depunct <- function(x) {
   # Diacritic flattening (precomposed Latin-1 / Latin Extended letters)
-  x <- gsub("[\u00f9\u00fa\u00fb\u00fc]", "u", x)            # \u00f9\u00fa\u00fb\u00fc
-  x <- gsub("[\u00d1]", "N", x)                              # \u00d1
+  x <- gsub("[\u00f9\u00fa\u00fb\u00fc]", "u", x) # \u00f9\u00fa\u00fb\u00fc
+  x <- gsub("[\u00d1]", "N", x) # \u00d1
   x <- gsub("[\u00c0\u00c1\u00c2\u00c3\u00c4\u00c5]", "A", x) # \u00c0\u00c1\u00c2\u00c3\u00c4\u00c5
-  x <- gsub("[\u00ec\u00ed\u00ee\u00ef]", "i", x)            # \u00ec\u00ed\u00ee\u00ef
+  x <- gsub("[\u00ec\u00ed\u00ee\u00ef]", "i", x) # \u00ec\u00ed\u00ee\u00ef
   x <- gsub("[\u00d2\u00d3\u00d4\u00d5\u00d6\u00d8]", "O", x) # \u00d2\u00d3\u00d4\u00d5\u00d6\u00d8
-  x <- gsub("[\u00c7]", "C", x)                              # \u00c7
-  x <- gsub("[\u00e6]", "ae", x)                             # \u00e6
-  x <- gsub("[\u00d0]", "D", x)                              # \u00d0
-  x <- gsub("[\u00fd\u00ff]", "y", x)                        # \u00fd\u00ff
-  x <- gsub("[\u00c8\u00c9\u00ca\u00cb]", "E", x)            # \u00c8\u00c9\u00ca\u00cb
-  x <- gsub("[\u00f1]", "n", x)                              # \u00f1
+  x <- gsub("[\u00c7]", "C", x) # \u00c7
+  x <- gsub("[\u00e6]", "ae", x) # \u00e6
+  x <- gsub("[\u00d0]", "D", x) # \u00d0
+  x <- gsub("[\u00fd\u00ff]", "y", x) # \u00fd\u00ff
+  x <- gsub("[\u00c8\u00c9\u00ca\u00cb]", "E", x) # \u00c8\u00c9\u00ca\u00cb
+  x <- gsub("[\u00f1]", "n", x) # \u00f1
   x <- gsub("[\u00e0\u00e1\u00e2\u00e3\u00e4\u00e5]", "a", x) # \u00e0\u00e1\u00e2\u00e3\u00e4\u00e5
   x <- gsub("[\u00f2\u00f3\u00f4\u00f5\u00f6\u00f8]", "o", x) # \u00f2\u00f3\u00f4\u00f5\u00f6\u00f8
-  x <- gsub("[\u00df]", "b", x)                              # \u00df
-  x <- gsub("[\u00d9\u00da\u00db\u00dc]", "U", x)            # \u00d9\u00da\u00db\u00dc
-  x <- gsub("[\u00de\u00fe]", "p", x)                        # \u00de\u00fe
-  x <- gsub("[\u00e7\u010d]", "c", x)                        # \u00e7\u010d
-  x <- gsub("[\u00cc\u00cd\u00ce\u00cf]", "I", x)            # \u00cc\u00cd\u00ce\u00cf
-  x <- gsub("[\u00f0]", "d", x)                              # \u00f0
-  x <- gsub("[\u00e8\u00e9\u00ea\u00eb]", "e", x)            # \u00e8\u00e9\u00ea\u00eb
-  x <- gsub("[\u00c6]", "Ae", x)                             # \u00c6
-  x <- gsub("[\u00dd]", "Y", x)                              # \u00dd
+  x <- gsub("[\u00df]", "b", x) # \u00df
+  x <- gsub("[\u00d9\u00da\u00db\u00dc]", "U", x) # \u00d9\u00da\u00db\u00dc
+  x <- gsub("[\u00de\u00fe]", "p", x) # \u00de\u00fe
+  x <- gsub("[\u00e7\u010d]", "c", x) # \u00e7\u010d
+  x <- gsub("[\u00cc\u00cd\u00ce\u00cf]", "I", x) # \u00cc\u00cd\u00ce\u00cf
+  x <- gsub("[\u00f0]", "d", x) # \u00f0
+  x <- gsub("[\u00e8\u00e9\u00ea\u00eb]", "e", x) # \u00e8\u00e9\u00ea\u00eb
+  x <- gsub("[\u00c6]", "Ae", x) # \u00c6
+  x <- gsub("[\u00dd]", "Y", x) # \u00dd
 
   # Parentheses to underscore (later stripped); ' and / et ' to ' & '
   x <- gsub("[()]", "_", x)
@@ -109,7 +109,9 @@ tt_depunct <- function(x) {
 #' @keywords internal
 #' @noRd
 tt_parsenames <- function(records) {
-  if (length(records) == 0) return(character(0))
+  if (length(records) == 0) {
+    return(character(0))
+  }
 
   records <- enc2utf8(records)
   id <- sub("\\|.*$", "", records)
@@ -121,9 +123,9 @@ tt_parsenames <- function(records) {
   name <- gsub(" ssp\\. ", " subsp. ", name)
 
   # parse_taxon_name: clean bad chars (lines 54-56)
-  name <- gsub("[\u00bf/\"]", "", name)  # remove \u00bf / "
-  name <- gsub("\u00a0", " ", name)       # non-breaking space -> space
-  name <- gsub("\u2014", "-", name)       # em dash -> hyphen
+  name <- gsub("[\u00bf/\"]", "", name) # remove \u00bf / "
+  name <- gsub("\u00a0", " ", name) # non-breaking space -> space
+  name <- gsub("\u2014", "-", name) # em dash -> hyphen
 
   # The big anchored parse regex (line 61); perl = TRUE to match gawk captures
   parsed <- sub(.tt_parse_re, "\\1|\\2|\\3|\\4|\\5|\\6|\\7", name, perl = TRUE)
@@ -153,17 +155,17 @@ tt_parsenames <- function(records) {
 
   depunct_eq <-
     gsub("\u00d7", "x", tt_depunct(remade)) ==
-    gsub("\u00d7", "x", tt_depunct(name))
+      gsub("\u00d7", "x", tt_depunct(name))
 
   fail <-
     !matched |
-    !grepl(.tt_v1, p1, perl = TRUE) |
-    !grepl(.tt_v2, p2, perl = TRUE) |
-    !grepl(.tt_v3, p3, perl = TRUE) |
-    !grepl(.tt_v4, p4, perl = TRUE) |
-    !grepl(.tt_v5, p5, perl = TRUE) |
-    !grepl(.tt_v6, p6, perl = TRUE) |
-    !depunct_eq
+      !grepl(.tt_v1, p1, perl = TRUE) |
+      !grepl(.tt_v2, p2, perl = TRUE) |
+      !grepl(.tt_v3, p3, perl = TRUE) |
+      !grepl(.tt_v4, p4, perl = TRUE) |
+      !grepl(.tt_v5, p5, perl = TRUE) |
+      !grepl(.tt_v6, p6, perl = TRUE) |
+      !depunct_eq
 
   # On failure the original returns "" -> output line is just `id|`
   out_parsed <- ifelse(fail, "", parsed)

--- a/R/ts_match_names.R
+++ b/R/ts_match_names.R
@@ -88,14 +88,14 @@
 #'   "Crepidomanes minutus",
 #'   c("Crepidomanes minutum", "Hymenophyllum polyanthos"),
 #'   simple = TRUE
-#'   )
+#' )
 #'
 #' # If names are too distant, they won't match
 #' ts_match_names(
 #'   query = "Crepidblah foo",
 #'   reference = c("Crepidomanes minutum", "Hymenophyllum polyanthos"),
 #'   simple = TRUE
-#'   )
+#' )
 #'
 #' # But we can force a match manually
 #' ts_match_names(
@@ -106,7 +106,7 @@
 #'     match = c("Crepidomanes minutum")
 #'   ),
 #'   simple = TRUE
-#'  )
+#' )
 #'
 #' # If you always want tibble output without specifying `tbl_out = TRUE`
 #' # every time, set the option:
@@ -114,18 +114,22 @@
 #' ts_match_names(
 #'   "Crepidomanes minutus",
 #'   c("Crepidomanes minutum", "Hymenophyllum polyanthos")
-#'   )
+#' )
 #'
 #' # Example using collapse_infra argument
 #' ts_match_names(
-#'   c("Crepidomanes minutus", "Blechnum lunare var. lunare",
-#'     "Blechnum lunare", "Bar foo var. foo", "Bar foo"),
-#'   c("Crepidomanes minutum", "Hymenophyllum polyanthos", "Blechnum lunare",
-#'     "Bar foo"),
+#'   c(
+#'     "Crepidomanes minutus", "Blechnum lunare var. lunare",
+#'     "Blechnum lunare", "Bar foo var. foo", "Bar foo"
+#'   ),
+#'   c(
+#'     "Crepidomanes minutum", "Hymenophyllum polyanthos", "Blechnum lunare",
+#'     "Bar foo"
+#'   ),
 #'   collapse_infra = TRUE,
 #'   collapse_infra_exclude = "Bar foo var. foo",
 #'   simple = TRUE
-#'   )
+#' )
 #'
 ts_match_names <- function(
   query,
@@ -245,8 +249,8 @@ ts_match_names <- function(
     query_parsed_df$same_infra_species <-
       (query_parsed_df$specific_epithet ==
         query_parsed_df$infraspecific_epithet) %in%
-      TRUE &
-      !query_parsed_df$name %in% collapse_infra_exclude
+        TRUE &
+        !query_parsed_df$name %in% collapse_infra_exclude
     assertthat::assert_that(!anyNA(query_parsed_df$same_infra_species))
     # For rows where infraspecific_epithet is the same as specific_epithet,
     # delete infraspecific_epithet and infraspecific_rank
@@ -415,10 +419,13 @@ ts_match_names <- function(
       )
   }
 
-  if (simple == TRUE)
+  if (simple == TRUE) {
     results <- dplyr::select(results, query, reference, match_type)
+  }
 
-  if (isTRUE(tbl_out)) return(tibble::as_tibble(results))
+  if (isTRUE(tbl_out)) {
+    return(tibble::as_tibble(results))
+  }
 
   results
 }

--- a/R/ts_parse_names.R
+++ b/R/ts_parse_names.R
@@ -27,7 +27,9 @@
 #' @examples
 #' ts_parse_names("Foogenus x barspecies var. foosubsp (L.) F. Bar")
 #' ts_parse_names(
-#'   "Foogenus x barspecies var. foosubsp (L.) F. Bar", tbl_out = TRUE)
+#'   "Foogenus x barspecies var. foosubsp (L.) F. Bar",
+#'   tbl_out = TRUE
+#' )
 #'
 #' # If you always want tibble output without specifying `tbl_out = TRUE`
 #' # every time, set the option:
@@ -53,7 +55,7 @@ ts_parse_names <- function(
   assertthat::assert_that(assertthat::is.flag(tbl_out))
 
   # Format input names for parsing as `id|taxon_name` records, for example
-  # `x-234|Foogenus x barspecies var. foosubsp (L.) F. Bar`
+  # `x-234|Foogenus x barspecies var. foosubsp (L.) F. Bar` # nolint: commented_code_linter.
   taxa_tbl <- ts_make_name_df(taxa)
   taxa_tbl$record <- paste(taxa_tbl$id, taxa_tbl$name, sep = "|")
 
@@ -90,7 +92,7 @@ ts_parse_names <- function(
 
   # Add "fail" column if all name parts are missing (couldn't be parsed properly)
   parsed_names$fail <- sapply(
-    1:nrow(parsed_names),
+    seq_len(nrow(parsed_names)),
     function(x) all(is.na(parsed_names[x, name_parts]))
   )
 
@@ -126,7 +128,9 @@ ts_parse_names <- function(
   # Return parsed names as dataframe or tibble
   results <- parsed_names[, c("name", "id", name_parts)]
 
-  if (isTRUE(tbl_out)) return(tibble::as_tibble(results))
+  if (isTRUE(tbl_out)) {
+    return(tibble::as_tibble(results))
+  }
 
   results
 }

--- a/R/ts_resolve_names.R
+++ b/R/ts_resolve_names.R
@@ -112,7 +112,7 @@ ts_resolve_names <- function(
   }
 
   # Classify results of matching
-  match_results_classified_with_taxonomy <-
+  match_results_classified <-
     match_results %>%
     ts_classify_result() %>%
     dplyr::select(query, reference, match_type, result_type) %>%
@@ -120,7 +120,7 @@ ts_resolve_names <- function(
 
   # Separate out single matches to an accepted name (success type 1)
   accepted_single_match <-
-    match_results_classified_with_taxonomy %>%
+    match_results_classified %>%
     # consider accepted names have either no acceptedNameUsageID or acceptedNameUsageID is same as taxonID
     dplyr::filter(
       (is.na(acceptedNameUsageID) |
@@ -139,7 +139,7 @@ ts_resolve_names <- function(
 
   # Separate out matches to a single synonym (success type 2)
   accepted_single_synonyms <-
-    match_results_classified_with_taxonomy %>%
+    match_results_classified %>%
     # Consider synonym anything with acceptedNameUsageID not matching taxonID
     dplyr::filter(!is.na(acceptedNameUsageID)) %>%
     dplyr::filter(acceptedNameUsageID != "") %>%
@@ -175,7 +175,7 @@ ts_resolve_names <- function(
 
   # Anything else is a failure
   failure <-
-    match_results_classified_with_taxonomy %>%
+    match_results_classified %>%
     dplyr::select(
       query,
       match_type,
@@ -205,7 +205,9 @@ ts_resolve_names <- function(
     )
 
   # Return as tibble or dataframe
-  if (isTRUE(tbl_out)) return(tibble::as_tibble(results))
+  if (isTRUE(tbl_out)) {
+    return(tibble::as_tibble(results))
+  }
 
   results
 }

--- a/R/ts_write_names.R
+++ b/R/ts_write_names.R
@@ -12,7 +12,7 @@
 #' @noRd
 ts_write_names <- function(df, path) {
   # Make vector of standard taxon-tools columns
-  tt_col_names = c(
+  tt_col_names <- c(
     "id",
     "genus_hybrid_sign",
     "genus_name",

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,7 +25,7 @@ ts_make_name_df <- function(taxa) {
   # ID is combination of first 8 chars of hash of the
   # input (taxa), followed by "-" and integer
   taxa_df <- data.frame(name = taxa)
-  taxa_df$id <- 1:nrow(taxa_df)
+  taxa_df$id <- seq_len(nrow(taxa_df))
   taxa_df$id <- paste(substr(digest::digest(taxa), 1, 8), taxa_df$id, sep = "-")
 
   taxa_df[, c("id", "name")]

--- a/README.Rmd
+++ b/README.Rmd
@@ -82,7 +82,8 @@ data(filmy_taxonomy)
 
 # Take a look at the columns used by taxastand
 head(filmy_taxonomy[c(
-  "taxonID", "acceptedNameUsageID", "taxonomicStatus", "scientificName")])
+  "taxonID", "acceptedNameUsageID", "taxonomicStatus", "scientificName"
+)])
 
 # As a test, resolve a misspelled name
 ts_resolve_names("Gonocormus minutum", filmy_taxonomy)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ data(filmy_taxonomy)
 
 # Take a look at the columns used by taxastand
 head(filmy_taxonomy[c(
-  "taxonID", "acceptedNameUsageID", "taxonomicStatus", "scientificName")])
+  "taxonID", "acceptedNameUsageID", "taxonomicStatus", "scientificName"
+)])
 #>    taxonID acceptedNameUsageID taxonomicStatus
 #> 1 54115096                  NA   accepted name
 #> 2 54133783            54115097         synonym

--- a/man/ts_match_names.Rd
+++ b/man/ts_match_names.Rd
@@ -120,14 +120,14 @@ ts_match_names(
   "Crepidomanes minutus",
   c("Crepidomanes minutum", "Hymenophyllum polyanthos"),
   simple = TRUE
-  )
+)
 
 # If names are too distant, they won't match
 ts_match_names(
   query = "Crepidblah foo",
   reference = c("Crepidomanes minutum", "Hymenophyllum polyanthos"),
   simple = TRUE
-  )
+)
 
 # But we can force a match manually
 ts_match_names(
@@ -138,7 +138,7 @@ ts_match_names(
     match = c("Crepidomanes minutum")
   ),
   simple = TRUE
- )
+)
 
 # If you always want tibble output without specifying `tbl_out = TRUE`
 # every time, set the option:
@@ -146,17 +146,21 @@ options(ts_tbl_out = TRUE)
 ts_match_names(
   "Crepidomanes minutus",
   c("Crepidomanes minutum", "Hymenophyllum polyanthos")
-  )
+)
 
 # Example using collapse_infra argument
 ts_match_names(
-  c("Crepidomanes minutus", "Blechnum lunare var. lunare",
-    "Blechnum lunare", "Bar foo var. foo", "Bar foo"),
-  c("Crepidomanes minutum", "Hymenophyllum polyanthos", "Blechnum lunare",
-    "Bar foo"),
+  c(
+    "Crepidomanes minutus", "Blechnum lunare var. lunare",
+    "Blechnum lunare", "Bar foo var. foo", "Bar foo"
+  ),
+  c(
+    "Crepidomanes minutum", "Hymenophyllum polyanthos", "Blechnum lunare",
+    "Bar foo"
+  ),
   collapse_infra = TRUE,
   collapse_infra_exclude = "Bar foo var. foo",
   simple = TRUE
-  )
+)
 
 }

--- a/man/ts_parse_names.Rd
+++ b/man/ts_parse_names.Rd
@@ -42,7 +42,9 @@ author, etc).
 \examples{
 ts_parse_names("Foogenus x barspecies var. foosubsp (L.) F. Bar")
 ts_parse_names(
-  "Foogenus x barspecies var. foosubsp (L.) F. Bar", tbl_out = TRUE)
+  "Foogenus x barspecies var. foosubsp (L.) F. Bar",
+  tbl_out = TRUE
+)
 
 # If you always want tibble output without specifying `tbl_out = TRUE`
 # every time, set the option:

--- a/tests/testthat/test-engine-vs-docker.R
+++ b/tests/testthat/test-engine-vs-docker.R
@@ -30,13 +30,16 @@ skip_if_no_image <- function() {
 # deliberate perturbations (ranks, hybrids, basionym/ex/in authors, diacritics).
 make_name_set <- function() {
   data(filmy_taxonomy, package = "taxastand", envir = environment())
-  base <- unique(filmy_taxonomy$scientificName)
+  base <- unique(filmy_taxonomy$scientificName) # nolint: object_usage_linter.
   base <- base[!is.na(base) & nzchar(base)]
   ranks <- c("var.", "subsp.", "f.", "fo.", "forma", "nothovar.")
   perturb <- unlist(lapply(utils::head(base, 200), function(nm) {
     parts <- strsplit(nm, " ")[[1]]
-    if (length(parts) < 2) return(NULL)
-    g <- parts[1]; s <- parts[2]
+    if (length(parts) < 2) {
+      return(NULL)
+    }
+    g <- parts[1]
+    s <- parts[2]
     c(
       paste0(g, " ", s, " ", ranks[1], " ", s),
       paste0("x ", g, " ", s),
@@ -100,15 +103,17 @@ test_that("tt_matchnames matches docker matchnames -F across options", {
 
   combos <- list(
     list(e = 10, o1 = FALSE, oc = FALSE),
-    list(e = 5,  o1 = FALSE, oc = FALSE),
-    list(e = 10, o1 = TRUE,  oc = FALSE),
+    list(e = 5, o1 = FALSE, oc = FALSE),
+    list(e = 10, o1 = TRUE, oc = FALSE),
     list(e = 10, o1 = FALSE, oc = TRUE),
-    list(e = 10, o1 = TRUE,  oc = TRUE)
+    list(e = 10, o1 = TRUE, oc = TRUE)
   )
 
   for (cb in combos) {
-    args <- c("matchnames", "-a", "/data/query.txt", "-b", "/data/ref.txt",
-              "-o", "/data/out.txt", "-e", cb$e, "-F")
+    args <- c(
+      "matchnames", "-a", "/data/query.txt", "-b", "/data/ref.txt",
+      "-o", "/data/out.txt", "-e", cb$e, "-F"
+    )
     if (cb$o1) args <- c(args, "-1")
     if (cb$oc) args <- c(args, "-c")
     docker_tt(dir, args)

--- a/vignettes/basics.Rmd
+++ b/vignettes/basics.Rmd
@@ -73,9 +73,12 @@ We can see this by querying the name without an author:
 ```{r match-example-1}
 ts_match_names(
   "Hymenophyllum wilsonii",
-  c("Hymenophyllum wilsonii Fée",
-    "Hymenophyllum wilsonii Hook."),
-  simple = TRUE)
+  c(
+    "Hymenophyllum wilsonii Fée",
+    "Hymenophyllum wilsonii Hook."
+  ),
+  simple = TRUE
+)
 ```
 
 `ts_match_names()` matches both scientific names[^1], because the algorithm it can't distinguish between them without additional information. So **it is almost always better to include the taxonomic author in the query**, to distinguish between such cases.
@@ -86,10 +89,13 @@ However, there can be quite a bit of variation in how authors are recorded. Some
 
 ```{r match-example-2}
 ts_match_names(
-  "Hymenophyllum taiwanense C. V. Morton", 
-  c("Hymenophyllum taiwanense (Tagawa) C. V. Morton", 
-    "Hymenophyllum taiwanense De Vol"), 
-  simple = TRUE)
+  "Hymenophyllum taiwanense C. V. Morton",
+  c(
+    "Hymenophyllum taiwanense (Tagawa) C. V. Morton",
+    "Hymenophyllum taiwanense De Vol"
+  ),
+  simple = TRUE
+)
 ```
 
 The name matching algorithm was able to narrow the match down to `Hymenophyllum taiwanense (Tagawa) C. V. Morton` even though the query lacked `(Tagawa)`. Furthermore, the `match_type` tells us how the matching was done: `auto_basio-` means an automatic match based on excluding the basionym author from the reference. **It is recommended to always check any results that weren't identical** (`exact`) to verify that the matching algorithm worked correctly, especially for fuzzy matches (`auto_fuzzy`). 
@@ -156,7 +162,8 @@ In this case, name resolution using the default settings produced `r nrow(natale
 ```{r name-res-example-4}
 ts_resolve_names(
   "Hymenophyllum natalense", filmy_taxonomy,
-  match_no_auth = TRUE)
+  match_no_auth = TRUE
+)
 ```
 
 Because the name *Hymenophyllum natalense* occurs only once in the reference, allowing matches without the author is enough to pin down a single, unambiguous match (labelled `auto_noauth`), which then resolves to its accepted name.

--- a/vignettes/benchmark.Rmd
+++ b/vignettes/benchmark.Rmd
@@ -20,7 +20,8 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 image <- "camwebb/taxon-tools:v1.3.0"
 has_docker <- tryCatch(
   system2("docker", c("image", "inspect", image),
-          stdout = FALSE, stderr = FALSE) == 0,
+    stdout = FALSE, stderr = FALSE
+  ) == 0,
   error = function(e) FALSE
 )
 ```
@@ -52,14 +53,17 @@ dir.create(dir)
 
 # Best-of-n elapsed seconds for a zero-argument function
 timeit <- function(f, reps = 2) {
-  min(vapply(seq_len(reps),
-             function(i) system.time(f())[["elapsed"]], numeric(1)))
+  min(vapply(
+    seq_len(reps),
+    function(i) system.time(f())[["elapsed"]], numeric(1)
+  ))
 }
 
 # Run a taxon-tools command in the Docker image, mounting `dir` at /data
 docker_run <- function(args) {
   system2("docker", c("run", "--rm", "-v", paste0(dir, ":/data"), image, args),
-          stdout = TRUE, stderr = FALSE)
+    stdout = TRUE, stderr = FALSE
+  )
 }
 
 base <- unique(filmy_taxonomy$scientificName)
@@ -105,7 +109,7 @@ matching step is timed.
 parse_lines <- function(x, prefix) {
   lines <- taxastand:::tt_parsenames(paste0(prefix, seq_along(x), "|", x))
   rest <- sub("^[^|]*\\|", "", lines)
-  lines[gsub("\\|", "", rest) != ""]      # drop unparseable names
+  lines[gsub("\\|", "", rest) != ""] # drop unparseable names
 }
 
 ref_lines <- parse_lines(base, "r")
@@ -125,11 +129,15 @@ writeLines(ref_lines, file.path(dir, "ref.txt"), useBytes = TRUE)
 writeLines(query_lines, file.path(dir, "query.txt"), useBytes = TRUE)
 
 match_rows <- lapply(c(5, 10), function(e) {
-  r_t <- timeit(function()
-    taxastand:::tt_matchnames(query_lines, ref_lines, max_dist = e))
-  d_t <- timeit(function() docker_run(c(
-    "matchnames", "-a", "/data/query.txt", "-b", "/data/ref.txt",
-    "-o", "/data/out.txt", "-e", e, "-F")))
+  r_t <- timeit(function() {
+    taxastand:::tt_matchnames(query_lines, ref_lines, max_dist = e)
+  })
+  d_t <- timeit(function() {
+    docker_run(c(
+      "matchnames", "-a", "/data/query.txt", "-b", "/data/ref.txt",
+      "-o", "/data/out.txt", "-e", e, "-F"
+    ))
+  })
 
   data.frame(
     `max_dist` = e,
@@ -143,8 +151,10 @@ match_tbl <- do.call(rbind, match_rows)
 ```
 
 ```{r match-table, eval = has_docker}
-cat(sprintf("%d queries against %d references\n",
-            length(query_lines), length(ref_lines)))
+cat(sprintf(
+  "%d queries against %d references\n",
+  length(query_lines), length(ref_lines)
+))
 knitr::kable(match_tbl, align = "r")
 ```
 
@@ -163,9 +173,11 @@ cat(
 p1 <- parse_tbl[parse_tbl$`Names parsed` == length(base), ]
 m10 <- match_tbl[match_tbl$max_dist == 10, ]
 cat(sprintf(
-  paste0("On this machine, parsing %s names took %.2fs in pure R vs %.2fs via ",
-         "taxon-tools (%s), and matching at the default `max_dist = 10` was ",
-         "%s faster.\n"),
+  paste0(
+    "On this machine, parsing %s names took %.2fs in pure R vs %.2fs via ",
+    "taxon-tools (%s), and matching at the default `max_dist = 10` was ",
+    "%s faster.\n"
+  ),
   format(length(base), big.mark = ","),
   p1$`pure R (s)`, p1$`taxon-tools (s)`, p1$`Speed-up`, m10$`Speed-up`
 ))


### PR DESCRIPTION
## Summary
- Ran `styler::style_pkg()` across the whole package. Purely cosmetic (brace wrapping, line wrapping, `=` -> `<-`, comment spacing) -- no logic changes, verified against the full test suite including the Docker-based differential test (byte-for-byte comparison against upstream `taxon-tools`).
- Added `.lintr` using `lintr::linters_with_defaults()`, with 3 linters deliberately disabled (rationale in the config file and commit message):
  - `indentation_linter` -- disagrees with styler on multi-line operator-chain continuation indents.
  - `pipe_consistency_linter` -- the package deliberately uses magrittr's `%>%` throughout and re-exports it for users; not a full `|>` migration in this PR.
  - `line_length_linter` -- many roxygen doc lines contain long, unbreakable markdown links (Darwin Core term URLs, the taxon-tools manual) that shouldn't be wrapped.
- Fixed genuine findings: 2x `1:nrow(...)` -> `seq_len(nrow(...))` (bug-prone on empty input), 3 lintr/styler indentation disagreements, 1 over-length variable name shortened.
- Added `# nolint` annotations for 4 false positives (documented inline): comments describing data formats/algorithms that `commented_code_linter` mistook for code, and a `data()`-loaded NSE binding in a test that static analysis can't see. Also wrapped `matchnames_engine.R`'s gawk-mirroring `A`/`B`/`Bmap`/etc. variable names in a `nolint` block, since they intentionally match the upstream script's naming for traceability (per that file's own header comment).
- `lintr::lint_package()` now reports **zero findings**.
- Added the `lint` GitHub Actions workflow so this stays enforced going forward.

## Test plan
- [x] `devtools::test()` passes locally (39 passed, 0 failed), including the Docker differential test.
- [x] `devtools::document()` regenerates the 2 affected `.Rd` files with only cosmetic example-formatting changes.
- [x] `lintr::lint_package()` reports zero findings.
- [ ] CI (R-CMD-check, coverage, and the new lint workflow) will validate on this PR.

Closes #21