### PR TITLE
Add CODE_OF_CONDUCT.md and CONTRIBUTING.md

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^\.claude$
 ^\.plans$
 ^codecov\.yml$
+^CODE_OF_CONDUCT\.md$
+^\.lintr$

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to taxastand
+
+This outlines how to propose a change to taxastand.
+
+By participating in this project you agree to abide by its
+[Contributor Code of Conduct](https://ropensci.org/code-of-conduct/).
+
+## Scope
+
+taxastand matches and standardizes taxonomic names against a
+user-supplied reference taxonomy (see the README for details). Feature
+requests that are really about a specific taxonomic database or web
+service are likely a better fit for packages like
+[taxize](https://github.com/ropensci/taxize) or
+[taxadb](https://github.com/ropensci/taxadb); if you're not sure, open
+an issue to discuss before starting work.
+
+## Filing an issue
+
+If you've found a bug, please file an issue that illustrates it with a
+minimal reproducible example. If you'd like to propose a new feature,
+open an issue describing what you'd like to see and why, before writing
+code — this saves everyone time if it turns out the feature is out of
+scope or needs a different approach.
+
+## Pull requests
+
+To contribute a change:
+
+1. Fork the repo and create a new branch from `main`.
+2. Make your change.
+3. If you've changed code, add or update tests as needed.
+4. Update documentation if you've changed function behavior or arguments
+   (run `devtools::document()` to regenerate `.Rd` files after editing
+   roxygen comments).
+5. Make sure the package passes checks locally before opening a PR (see
+   below).
+6. Push your branch and open a pull request describing the change.
+
+For small fixes (typos, obvious bugs), feel free to skip the issue and go
+straight to a pull request.
+
+## Running checks locally
+
+```r
+# Install development dependencies
+devtools::install_dev_deps()
+
+# Run the test suite
+devtools::test()
+
+# Check code style (uses the .lintr config in this repo)
+lintr::lint_package()
+
+# Auto-format code to match the project's style
+styler::style_pkg()
+
+# Full package check (mirrors CI)
+devtools::check()
+```
+
+Some tests compare taxastand's pure-R matching engine against the
+original [taxon-tools](https://github.com/camwebb/taxon-tools) Docker
+image; these are skipped automatically if Docker isn't available, so
+you don't need Docker to contribute.
+
+## Code style
+
+Code is formatted with [styler](https://styler.r-lib.org/) and linted
+with [lintr](https://lintr.r-lib.org/) (see `.lintr` for the active
+rules). Please run both before opening a PR.
+
+## Documentation infrastructure
+
+Function documentation is written as [roxygen2](https://roxygen2.r-lib.org/)
+comments above each function in `R/`, not edited directly in `man/`.
+Run `devtools::document()` to regenerate `.Rd` files and `NAMESPACE`
+after changing roxygen comments.
+
+## Package lifecycle
+
+taxastand is under active development. Its public API
+(`ts_parse_names()`, `ts_match_names()`, `ts_resolve_names()`) is
+considered stable; internal functions may change without notice.
+
+## Acknowledging contributions
+
+Contributors who make a substantial code contribution will be credited
+in `DESCRIPTION` (`Authors@R`, role `ctb`) and `NEWS.md`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+English: Refer to [rOpenSci Code of Conduct](https://ropensci.org/code-of-conduct/). 
+
+Español: Consulte el [Código de conducta de rOpenSci](https://ropensci.org/es/codigo-de-conducta/).

--- a/README.Rmd
+++ b/README.Rmd
@@ -93,6 +93,16 @@ ts_resolve_names("Gonocormus minutum", filmy_taxonomy)
 # reference taxonomy.
 ```
 
+## Contributing
+
+Contributions are welcome! Please see the
+[contributing guide](.github/CONTRIBUTING.md) for how to file issues,
+submit pull requests, and run checks locally.
+
+Please note that this package is released with a [Contributor Code of
+Conduct](https://ropensci.org/code-of-conduct/). By contributing to this
+project, you agree to abide by its terms.
+
 ## Citing this package
 
 If you use this package, please cite it! Here is an example:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ ts_resolve_names("Gonocormus minutum", filmy_taxonomy)
 # reference taxonomy.
 ```
 
+## Contributing
+
+Contributions are welcome! Please see the [contributing
+guide](.github/CONTRIBUTING.md) for how to file issues, submit pull
+requests, and run checks locally.
+
+Please note that this package is released with a [Contributor Code of
+Conduct](https://ropensci.org/code-of-conduct/). By contributing to this
+project, you agree to abide by its terms.
+
 ## Citing this package
 
 If you use this package, please cite it! Here is an example:


### PR DESCRIPTION
## Summary
Per rOpenSci's devguide (Collaboration Guide / "Friendly files", https://devguide.ropensci.org/maintenance_collaboration.html):

- `CODE_OF_CONDUCT.md` content is now the rOpenSci GitHub org's default CoC pointer file, byte-for-byte (per the devguide: use this content pre-transfer to the `ropensci` org, then delete the file entirely if/when the repo is transferred, since the org's default CoC will apply automatically).
- `CONTRIBUTING.md` moved to `.github/CONTRIBUTING.md` (the devguide's required location), and expanded per its content recommendations: a scope statement, roxygen2/documentation infra notes, a package lifecycle statement, and how contributions are acknowledged — in addition to how to file issues/PRs and run checks locally.
- README.Rmd's "Contributing" section now uses the devguide's exact recommended CoC text/link (`https://ropensci.org/code-of-conduct/`) and links to the relocated `CONTRIBUTING.md`.
- Removed the now-redundant `CONTRIBUTING.md` entry from `.Rbuildignore` (`.github/` as a whole is already ignored).

## Test plan
- [x] `devtools::build_readme()` re-knit cleanly with the new section and links.
- [x] `devtools::test()` passes locally (39 passed, 0 failed).
- [x] CI will validate on this PR.

Closes #14