### PR TITLE
Add inst/CITATION and CITATION.cff

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^codecov\.yml$
 ^CODE_OF_CONDUCT\.md$
 ^\.lintr$
+^CITATION\.cff$

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,275 @@
+# ------------------------------------------------
+# CITATION.cff file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# ------------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "taxastand" in publications use:'
+type: software
+license: MIT
+title: 'taxastand: Taxonomic Name Standardization'
+version: 2.0.0
+doi: 10.5281/zenodo.5726390
+abstract: Standardizes taxonomic names by matching species names to entries in a user-supplied
+  reference taxonomy, then resolving synonyms to their accepted names. Fuzzy matching
+  on parsed name components (genus, epithet, author, infraspecific rank, etc.) allows
+  for orthographic differences between the query and reference names. This facilitates
+  reproducible joining of datasets that use different taxonomic synonyms for the same
+  species.
+authors:
+- family-names: Nitta
+  given-names: Joel
+  email: joelnitta@gmail.com
+  orcid: https://orcid.org/0000-0003-4719-7472
+preferred-citation:
+  type: manual
+  title: 'taxastand: Taxonomic Name Standardization'
+  authors:
+  - family-names: Nitta
+    given-names: Joel
+    email: joelnitta@gmail.com
+    orcid: https://orcid.org/0000-0003-4719-7472
+  year: '2026'
+  notes: R package version 2.0.0
+  url: https://joelnitta.github.io/taxastand/
+  doi: 10.5281/zenodo.5726390
+repository-code: https://github.com/joelnitta/taxastand
+url: https://joelnitta.github.io/taxastand/
+contact:
+- family-names: Nitta
+  given-names: Joel
+  email: joelnitta@gmail.com
+  orcid: https://orcid.org/0000-0003-4719-7472
+keywords:
+- database
+- r
+- r-package
+- rstats
+- taxonomy
+references:
+- type: software
+  title: assertthat
+  abstract: 'assertthat: Easy Pre and Post Assertions'
+  notes: Imports
+  repository: https://CRAN.R-project.org/package=assertthat
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@rstudio.com
+  year: '2026'
+  doi: 10.32614/CRAN.package.assertthat
+- type: software
+  title: digest
+  abstract: 'digest: Create Compact Hash Digests of R Objects'
+  notes: Imports
+  url: https://eddelbuettel.github.io/digest/
+  repository: https://CRAN.R-project.org/package=digest
+  authors:
+  - family-names: Eddelbuettel
+    given-names: Dirk
+    email: edd@debian.org
+    orcid: https://orcid.org/0000-0001-6419-907X
+  year: '2026'
+  doi: 10.32614/CRAN.package.digest
+- type: software
+  title: dplyr
+  abstract: 'dplyr: A Grammar of Data Manipulation'
+  notes: Imports
+  url: https://dplyr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=dplyr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: François
+    given-names: Romain
+    orcid: https://orcid.org/0000-0002-2444-4226
+  - family-names: Henry
+    given-names: Lionel
+  - family-names: Müller
+    given-names: Kirill
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Vaughan
+    given-names: Davis
+    email: davis@posit.co
+    orcid: https://orcid.org/0000-0003-4777-038X
+  year: '2026'
+  doi: 10.32614/CRAN.package.dplyr
+- type: software
+  title: fs
+  abstract: 'fs: Cross-Platform File System Operations Based on ''libuv'''
+  notes: Imports
+  url: https://fs.r-lib.org
+  repository: https://CRAN.R-project.org/package=fs
+  authors:
+  - family-names: Hester
+    given-names: Jim
+  - family-names: Wickham
+    given-names: Hadley
+  - family-names: Csárdi
+    given-names: Gábor
+  year: '2026'
+  doi: 10.32614/CRAN.package.fs
+- type: software
+  title: glue
+  abstract: 'glue: Interpreted String Literals'
+  notes: Imports
+  url: https://glue.tidyverse.org/
+  repository: https://CRAN.R-project.org/package=glue
+  authors:
+  - family-names: Hester
+    given-names: Jim
+    orcid: https://orcid.org/0000-0002-2739-7082
+  - family-names: Bryan
+    given-names: Jennifer
+    email: jenny@posit.co
+    orcid: https://orcid.org/0000-0002-6983-2759
+  year: '2026'
+  doi: 10.32614/CRAN.package.glue
+- type: software
+  title: magrittr
+  abstract: 'magrittr: A Forward-Pipe Operator for R'
+  notes: Imports
+  url: https://magrittr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=magrittr
+  authors:
+  - family-names: Bache
+    given-names: Stefan Milton
+    email: stefan@stefanbache.dk
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.magrittr
+- type: software
+  title: tibble
+  abstract: 'tibble: Simple Data Frames'
+  notes: Imports
+  url: https://tibble.tidyverse.org/
+  repository: https://CRAN.R-project.org/package=tibble
+  authors:
+  - family-names: Müller
+    given-names: Kirill
+    email: kirill@cynkra.com
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@rstudio.com
+  year: '2026'
+  doi: 10.32614/CRAN.package.tibble
+- type: software
+  title: tidyr
+  abstract: 'tidyr: Tidy Messy Data'
+  notes: Imports
+  url: https://tidyr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=tidyr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  - family-names: Vaughan
+    given-names: Davis
+    email: davis@posit.co
+  - family-names: Girlich
+    given-names: Maximilian
+  year: '2026'
+  doi: 10.32614/CRAN.package.tidyr
+- type: software
+  title: 'R: A Language and Environment for Statistical Computing'
+  notes: Depends
+  url: https://www.R-project.org/
+  authors:
+  - name: R Core Team
+    website: https://ror.org/02zz1nj61
+  institution:
+    name: R Foundation for Statistical Computing
+    website: https://ror.org/05qewa988
+    address: Vienna, Austria
+  year: '2026'
+  doi: 10.32614/R.manuals
+  version: '>= 4.1.0'
+- type: software
+  title: rmarkdown
+  abstract: 'rmarkdown: Dynamic Documents for R'
+  notes: Suggests
+  url: https://pkgs.rstudio.com/rmarkdown/
+  repository: https://CRAN.R-project.org/package=rmarkdown
+  authors:
+  - family-names: Allaire
+    given-names: JJ
+    email: jj@posit.co
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  - family-names: Dervieux
+    given-names: Christophe
+    email: cderv@posit.co
+    orcid: https://orcid.org/0000-0003-4474-2498
+  - family-names: McPherson
+    given-names: Jonathan
+    email: jonathan@posit.co
+  - family-names: Luraschi
+    given-names: Javier
+  - family-names: Ushey
+    given-names: Kevin
+    email: kevin@posit.co
+  - family-names: Atkins
+    given-names: Aron
+    email: aron@posit.co
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  - family-names: Cheng
+    given-names: Joe
+    email: joe@posit.co
+  - family-names: Chang
+    given-names: Winston
+    email: winston@posit.co
+  - family-names: Iannone
+    given-names: Richard
+    email: rich@posit.co
+    orcid: https://orcid.org/0000-0003-3925-190X
+  year: '2026'
+  doi: 10.32614/CRAN.package.rmarkdown
+- type: software
+  title: knitr
+  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
+  notes: Suggests
+  url: https://yihui.org/knitr/
+  repository: https://CRAN.R-project.org/package=knitr
+  authors:
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  year: '2026'
+  doi: 10.32614/CRAN.package.knitr
+- type: software
+  title: roxyglobals
+  abstract: 'roxyglobals: ''Roxygen2'' Global Variable Declarations'
+  notes: Suggests
+  url: https://github.com/anthonynorth/roxyglobals
+  repository: https://CRAN.R-project.org/package=roxyglobals
+  authors:
+  - family-names: North
+    given-names: Anthony
+    email: anthony.jl.north@gmail.com
+  year: '2026'
+  doi: 10.32614/CRAN.package.roxyglobals
+  version: '>= 1.0.0'
+- type: software
+  title: testthat
+  abstract: 'testthat: Unit Testing for R'
+  notes: Suggests
+  url: https://testthat.r-lib.org
+  repository: https://CRAN.R-project.org/package=testthat
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.testthat
+  version: '>= 3.0.0'
+

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,13 @@
+bibentry(
+  bibtype = "Manual",
+  title = "taxastand: Taxonomic Name Standardization",
+  author = person(
+    given = "Joel", family = "Nitta",
+    email = "joelnitta@gmail.com",
+    comment = c(ORCID = "0000-0003-4719-7472")
+  ),
+  year = "2026",
+  note = sprintf("R package version %s", meta$Version),
+  url = "https://joelnitta.github.io/taxastand/",
+  doi = "10.5281/zenodo.5726390"
+)


### PR DESCRIPTION
## Summary
- `inst/CITATION` uses `bibentry()` (not the deprecated `citEntry()`), referencing the Zenodo concept DOI (`10.5281/zenodo.5726390`) already used in the README's citation example.
- `CITATION.cff` generated via `cffr::cff_write()` for machine-readable citation metadata; also picks up dependency metadata automatically from DESCRIPTION.
- Verified `citation("taxastand")` renders correctly (both human-readable and BibTeX forms).

## Test plan
- [x] `citation("taxastand")` renders the expected output.
- [x] `cffr::cff_write()` validated `CITATION.cff` as valid CFF 1.2.0.
- [x] `devtools::test()` passes locally (39 passed, 0 failed).
- [x] `lintr::lint_package()` reports zero findings.
- [x] CI will validate on this PR.

Closes #18