### PR TITLE
Refresh README badges and project status messaging

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 # taxastand <img src="man/figures/logo.png" align="right" alt="" width="120" />
 
 <!-- badges: start -->
-[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![DOI](https://zenodo.org/badge/192684959.svg)](https://zenodo.org/badge/latestdoi/192684959)
 [![R-CMD-check](https://github.com/joelnitta/taxastand/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/joelnitta/taxastand/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/joelnitta/taxastand/graph/badge.svg)](https://app.codecov.io/gh/joelnitta/taxastand)

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 <!-- badges: start -->
 
-[![Project Status: WIP – Initial development is in progress, but there
-has not yet been a stable, usable release suitable for the
-public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
+[![Project Status: Active – The project has reached a stable, usable
+state and is being actively
+developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![DOI](https://zenodo.org/badge/192684959.svg)](https://zenodo.org/badge/latestdoi/192684959)
 [![R-CMD-check](https://github.com/joelnitta/taxastand/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/joelnitta/taxastand/actions/workflows/R-CMD-check.yaml)
 [![Codecov test


### PR DESCRIPTION
## Summary
Replaced the repostatus "WIP" badge ("Initial development is in progress, but there has not yet been a stable, usable release suitable for the public") with "Active" ("The project has reached a stable, usable state and is being actively developed") — accurate now that the package is on v2.0.0 with a pure-R implementation, rather than still saying it's pre-release.

R-CMD-check and Codecov badges were already added in earlier PRs (#15, #16), so nothing further was needed there.

## Test plan
- [x] `devtools::build_readme()` re-knit cleanly.
- [x] `devtools::test()` passes locally (39 passed, 0 failed).
- [x] `lintr::lint_package()` reports zero findings.
- [x] CI will validate on this PR.

Closes #17